### PR TITLE
Revamp readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,234 +1,540 @@
-##### I set this up some years ago to centralize sheet music I found online but had to make it private for some reason. Anyway, it’s back now.
+# PianoSheets
 
-###### All credits belong to their respective artists. Will be updating this repo regularly as I learn/acquire new sheet music, enjoy :)
-###### All sheets were already made public and pulled from public sites such as Scribd, Musescore, free-scores, etc.
-###### P.S. This readme could be outdated, see [tree.txt](https://github.com/JKleinne/PianoSheets/blob/master/tree.txt) for a more up-to-date list of contents
- **Table of Contents**
-* [Kyle Landry](#kyle-landry)
-  - [Anime](#anime)
-  - [Christmas](#christmas)
-  - [Disney](#disney)
-  - [Games](#games)
-  - [Movies](#movies)
-* [Vika Yermalova (Vkgoeswild)](#vkgoeswild)
-* [Zohar002](#zohar)
-* [Jazz](#jazz)
-  - [Hans Piano](#hans-piano)
-  - [Jonny May](#jonny-may)
-  - [Rupert Austin](#rpa)
+A curated personal collection of **1,583 piano sheet music files** across **102 directories**, organized primarily by arranger/composer. Covers classical repertoire, film scores, jazz standards, anime, video games, rock/pop adaptations, and more.
 
-### <a name="kyle-landry"></a> Kyle Landry
- Sheet | YouTube/Sample
- --- | --- 
- [Game Of Thrones Medley](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Game%20Of%20Thrones.pdf) | [Youtube](https://www.youtube.com/watch?v=NIVfy1V-_n0)
- [River Flows In You](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/River%20flows%20in%20you.pdf) | [Youtube](https://www.youtube.com/watch?v=qFwWE_flqcI)
- [SKY - Forever](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Sky%20-%20Forever.pdf) | [Youtube](https://www.youtube.com/watch?v=CsUu0qknxW8)
- <a name="anime"></a> ***Anime*** |
- [Pokemon - Gotta Catch 'Em All](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Pokemon%20-%20Gotta%20catch%20'em%20all.pdf) | [Youtube](https://www.youtube.com/watch?v=vZ3gPXVMWRY)
- [Fairy Tail - Main Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Fairy%20Tail%20Theme.pdf) | [Youtube](https://www.youtube.com/watch?v=dIqpUqwlWN4)
- [One Piece - Eyecatcher](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/One%20Piece/One%20Piece%20-%20Eyecatcher.pdf) | [Youtube](https://www.youtube.com/watch?v=HV8UbEbA2hk)
- [One Piece - Gold and Oden](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/One%20Piece/One%20Piece%20-%20Gold%20and%20Oden.pdf) | [Youtube](https://www.youtube.com/watch?v=HV8UbEbA2hk)
- [Naruto - Medley Special (Wind - Hokage Funeral - Sadness and Sorrow)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Naruto/Medley%20Special.pdf) | [Youtube](https://www.youtube.com/watch?v=ntkRQCh8c_Y)
- [Naruto - Alone](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Naruto/Alone.pdf) | [Youtube](https://www.youtube.com/watch?v=irEIwQBGKpg)
- [Naruto - Hinata vs Neji](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Naruto/Hinata%20VS%20Neji.pdf) | [Youtube](https://www.youtube.com/watch?v=X0qI66ix-QY)
- [Sword Art Online - Main Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Sword%20Art%20Online/SAO%20Main%20Theme.pdf) | [Youtube](https://www.youtube.com/watch?v=XzGl9B_cKOw)
- [Sword Art Online - Crossing Field](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Sword%20Art%20Online/Sword%20Art%20Online%20OP%20-%20Crossing%20Field.pdf) | [Youtube](https://www.youtube.com/watch?v=kGeQTdl7P1Q)
- [Kimi ni Todoke - Opening Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Kimi%20ni%20Todoke/Opening%20Theme.pdf) | [Youtube](https://www.youtube.com/watch?v=QQUiBgURdDM)
- [Kimi ni Todoke - Ending Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Kimi%20ni%20Todoke/Kataomoi.pdf) | [Youtube](https://www.youtube.com/watch?v=Vurr59c29Wo&t=2s)
- [Clannad - Dango Daikazoku](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Clannad%20-%20Dango%20Daikazoku.pdf) | [Youtube](https://www.youtube.com/watch?v=SlgNA49E7lI)
- [Elfen Lied - Lilium](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Elfen%20Lied%20-%20Lilium.pdf) | [Youtube](https://www.youtube.com/watch?v=sjXxCr_E1So)
- [Fate/Stay Night - Anata Ga Ita Mori](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Fate_Stay%20Night%20-%20Anata%20Ga%20Ita%20Mori.pdf) | [Youtube](https://www.youtube.com/watch?v=YzrrnLN3tF8)
- [Inuyasha - Every Heart](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Inu%20Yasha%20-%20Every%20Heart.pdf) | [Youtube](https://www.youtube.com/watch?v=IwTbRTIK2mQ)
- [Nodame Cantabile - Allegro Cantabile](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Nodame%20Cantabile%20OP%20-%20Allegro%20Cantabile.pdf) | [Youtube](https://www.youtube.com/watch?v=v5v3v4bWXGE)
- [Wolf's Rain](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Wolfs%20Rain%20-%20Gravity.pdf) | [Youtube](https://www.youtube.com/watch?v=6RLgoQ0Pk7o)
- <a name="christmas"></a> ***Christmas*** |
- [Christmas Carol Medley](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Christmas/Christmas%20Carol%20Medley.pdf) | [Youtube](https://www.youtube.com/watch?v=pY7xGIGEch4)
- [Christmas Medley Special](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Christmas/Christmas%20Medley%20Special.pdf) | [Youtube](https://www.youtube.com/watch?v=GGBzsRFoCgA)
- [Jingle Bells / Sleigh Ride](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Christmas/Jingle%20Bells%2BSleigh%20Ride.pdf) | [Youtube](https://www.youtube.com/watch?v=pirei3xYidA)
- [Joy to the World](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Christmas/Joy%20to%20the%20World.pdf) | [Youtube](https://www.youtube.com/watch?v=0UTJhzvhHSU)
- [Silent Night](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Christmas/Silent%20Night.pdf) | [Youtube](https://www.youtube.com/watch?v=mOhuiezfxT4)
- <a name="disney"></a> ***Disney*** |
- [Beauty and the Beast - Main Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Beauty%20and%20the%20Beast/Beauty%20and%20the%20Beast.pdf) | [Youtube](https://www.youtube.com/watch?v=AyhPxrchntM)
- [Beauty and the Beast - Be Our Guest](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Beauty%20and%20the%20Beast/Be%20Our%20Guest.pdf) | [Youtube](https://www.youtube.com/watch?v=vu2W2W8beRg)
- [Beauty and the Beast - Something There](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Beauty%20and%20the%20Beast/Something%20There.pdf) | [Youtube](https://www.youtube.com/watch?v=mfhM2y1aV48)
- [Mulan - Reflection](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Mulan/Reflection.pdf) | [Youtube](https://www.youtube.com/watch?v=A0OXk5BC350)
- [Mulan - I'll Make a Man Out of You](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Mulan/I'll%20Make%20a%20Man%20Out%20of%20You.pdf) | [Youtube](https://www.youtube.com/watch?v=OkP0XYvGBfs)
- [The Lion King - Can You Feel The Love Tonight](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/The%20Lion%20King/Can%20you%20feel%20the%20love%20tonight.pdf) | [Youtube](https://www.youtube.com/watch?v=9QG6vY2dYQE)
- [The Lion King - Circle of Life](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/The%20Lion%20King/Circle%20of%20Life.pdf) | [Youtube](https://www.youtube.com/watch?v=V_xdoMWLyS8)
- [The Lion King - King Of Pride Rock](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/The%20Lion%20King/King%20of%20Pride%20Rock.pdf) | [Youtube](https://www.youtube.com/watch?v=jJsiB3BuNIw)
- [The Lion King - This Land](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/The%20Lion%20King/This%20Land.pdf) | [Youtube](https://www.youtube.com/watch?v=_w4DBpxOx_s)
- [Aladdin - A Whole New World](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Aladdin%20-%20A%20Whole%20New%20World.pdf) | [Youtube](https://www.youtube.com/watch?v=BxTA6wn4qzI)
- [Enchanted - So Close](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Enchanted%20-%20So%20Close.pdf) | [Youtube](https://www.youtube.com/watch?v=41WJ6jD3EtQ)
- [Frozen - Let It Go](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Frozen%20-%20Let%20it%20go.pdf) | [Youtube](https://www.youtube.com/watch?v=tBAQd2v-_J4)
- [Hercules - I Can Go The Distance](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Hercules%20-%20I%20Can%20Go%20The%20Distance.pdf) | [Youtube](https://www.youtube.com/watch?v=pUIhted5gEE)
- [The Little Mermaid - Part Of Your World](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Part%20of%20Your%20World.pdf) | [Youtube](https://www.youtube.com/watch?v=_1ikn2ZYC5Q)
- [Pinocchio - When You Wish Upon A Star](https://github.com/mstty/PianoSheets/blob/master/Kyle%20Landry/Disney/Pinocchio%20-%20When%20You%20Wish%20Upon%20A%20Star.pdf) | [Youtube](https://www.youtube.com/watch?v=GmVlJaFUnqQ)
- [Up - Married Life](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Pixar's%20Up%20-%20Married%20Life.pdf) | [Youtube](https://www.youtube.com/watch?v=fnyEi4qeuAk)
- [Pocahontas - Colors Of The Wind](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Pocahontas%20-%20Colors%20of%20The%20Wind.pdf) | [Youtube](https://www.youtube.com/watch?v=s1ERVXHNSJQ)
- [Tangled - I See The Light](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Tangled%20-%20I%20See%20The%20Light.pdf) | [Youtube](https://www.youtube.com/watch?v=UH6u0109yzo)
- [Tarzan - You'll Be In My Heart](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Tarzan%20-%20You'll%20Be%20In%20My%20Heart.pdf) | [Youtube](https://www.youtube.com/watch?v=93T1BdwkCY8)
- [The Hunchback Of Notre-Dame - God Help The Outcasts](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/The%20Hunchback%20of%20Notre-Dame%20-%20God%20Help%20The%20Outcasts.pdf) | [Youtube](https://www.youtube.com/watch?v=frlLFFHrhF4)
- <a name="games"></a> ***Games*** |
- [League of Legends - Summoners Call](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/League%20of%20Legends%20-%20Summoners%20Call.pdf) | [Youtube](https://www.youtube.com/watch?v=86uO4rXgtJc)
- [Skyrim - Main Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Skyrim%20-%20Main%20Theme.pdf) | [Youtube](https://www.youtube.com/watch?v=gkDCQcP89_Y)
- [Chrono Trigger - Yearnings Of The Wind (600 AD)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Chrono%20Trigger%20-%20Yearnings%20Of%20The%20Wind.pdf) | [Youtube](https://www.youtube.com/watch?v=V1pgSY48mgE)
- [Chrono Cross - Scars of Time](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Chrono%20Cross%20-%20Scars%20Of%20Time.pdf) | [Youtube](https://www.youtube.com/watch?v=x49UCaNqhKw)
- [Halo 3 - Never Forget](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Halo%203%20-%20Never%20Forget.pdf) | [Youtube](https://www.youtube.com/watch?v=ZJZrmEEbFxo)
- [Final Fantasy - Aerith's Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Final%20Fantasy/Aeriths%20Theme.pdf) | [Youtube](https://www.youtube.com/watch?v=d_0QkFBtQxQ)
- [Final Fantasy - 1000 Words](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Final%20Fantasy/1000%20Words.pdf) | [Youtube](https://www.youtube.com/watch?v=J4AVo_6OuNI)
- [Final Fantasy - Eternity (Memory Of Light And Waves)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Final%20Fantasy/Eternity%20(Memory%20of%20Lightwaves).pdf) | [Youtube](https://www.youtube.com/watch?v=vTMyGACAGe8)
- [Final Fantasy - To Zanarkand](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Final%20Fantasy/To%20Zanarkand.pdf) | [Youtube](https://www.youtube.com/watch?v=yPnu4eyAq2A)
- [Final Fantasy - Terra's Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Final%20Fantasy/Terras%20Theme.pdf) | [Youtube](https://www.youtube.com/watch?v=IJELF5oFl0Q)
- [Kingdom Hearts - Dearly Beloved (2008)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Kingdom%20Hearts/Dearly%20Beloved%20(2008).pdf) | [Youtube](https://www.youtube.com/watch?v=a4-sqvJRm5U)
- [Kingdom Hearts - Dearly Beloved (2009)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Kingdom%20Hearts/Dearly%20Beloved%20(2009).pdf) | [Youtube](https://www.youtube.com/watch?v=-FgYwY5F5P4)
- [Kingdom Hearts - Dearly Beloved (2010)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Kingdom%20Hearts/Dearly%20Beloved%20(2010).pdf) | [Youtube](https://www.youtube.com/watch?v=eQ0E3dsHRV4)
- [Kingdom Hearts - Dearly Beloved (2012)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Kingdom%20Hearts/Dearly%20Beloved%20(2012).pdf) | [Youtube](https://www.youtube.com/watch?v=6Ujdk26C7JA)
- [Kingdom Hearts - Dearly Beloved (2013)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Kingdom%20Hearts/Dearly%20Beloved%20(2013).pdf) | [Youtube](https://www.youtube.com/watch?v=bItsQnOxds0)
- [Kingdom Hearts - Dearly Beloved (Soft Edition)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Kingdom%20Hearts/Dearly%20Beloved%20(Soft%20Edition).pdf) | [Youtube](https://www.youtube.com/watch?v=Cg-EzLwC83A)
- [Kingdom Hearts - Hikari](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Kingdom%20Hearts/Hikari.pdf) | [Youtube](https://www.youtube.com/watch?v=YUOYZbDhfos)
- [Kingdom Hearts - Kairi](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Kingdom%20Hearts/Kairi.pdf) | [Youtube](https://www.youtube.com/watch?v=3ZvmFFrPGQM)
- [Kingdom Hearts - Passion](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Kingdom%20Hearts/Passion.pdf) | [Youtube](https://www.youtube.com/watch?v=-neZL4_O6sQ)
- [Mario - Super Mario World Castle Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Mario/Super%20Mario%20World%20Castle%20Theme.pdf) | [Youtube](https://www.youtube.com/watch?v=w9rI3Vf-qPI)
- [Mario - Super Mario 64 Dire Dire Docks](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Mario/Dire%20Dire%20Docks.pdf) | [Youtube](https://www.youtube.com/watch?v=80eFXnb9Uro)
- [Mario - Super Mario Galaxy Rosalina's Observatory](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Mario/Rosalinas%20Observatory.pdf) | [Youtube](https://www.youtube.com/watch?v=dd0vGfL4hgw)
- [Mario - Super Mario Brothers 2 Overworld Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Mario/Super%20Mario%20Overworld%20Theme.pdf) | [Youtube](https://www.youtube.com/watch?v=fej_4T8wmEE)
- [Mario - Super Mario RPG Mallow Finds Out He Is Not A Tadpole (Sad Song)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Mario/Super%20Mario%20RPG%20-%20Mallow%20Finds%20Out%20He%20Is%20Not%20A%20Tadpole.pdf) | [Youtube](https://www.youtube.com/watch?v=MycyQKZSg2M)
- [Pokemon - Medley](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Pokemon/Pokemon%20Medley.pdf) | [Youtube](https://www.youtube.com/watch?v=tOYIbV5y7FI)
- [Pokemon - Elite Four](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Pokemon/Elite%20Four.pdf) | [Youtube](https://www.youtube.com/watch?v=vWXtr3MRms0)
- [Pokemon - Ruby/Sapphire Ending Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Pokemon/Pokemon%20Ruby%20And%20Sapphire%20Ending%20Theme.pdf) | [Youtube](https://www.youtube.com/watch?v=_4VZgQiKbns)
- [The Legend of Zelda - Medley](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Zelda/Zelda%20Medley%20-%20Full%20Score.pdf) | [Youtube](https://www.youtube.com/watch?v=3p3MhflI8WQ)
- [The Legend of Zelda - Gerudo Valley](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Zelda/Gerudo%20Valley.pdf) | [Youtube](https://www.youtube.com/watch?v=QkC6mZa9Jrc)
- [The Legend of Zelda - Gerudo Valley (2013)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Zelda/Gerudo%20Valley%20(2013).pdf) | [Youtube](https://www.youtube.com/watch?v=lYLrPbngWHw)
- [The Legend of Zelda - Overworld Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Zelda/Overworld%20Theme.pdf) | [Youtube](https://www.youtube.com/watch?v=QwR_xbzVOvM)
- [The Legend of Zelda - Song Of Healing](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Zelda/Song%20of%20Healing.pdf) | [Youtube](https://www.youtube.com/watch?v=LUq49NecOeE)
- <a name="movies"></a> ***Movies*** |
- [Harry Potter - Medley](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Harry%20Potter/Hedwig's%20Theme.pdf) | [Youtube](https://www.youtube.com/watch?v=NzAXLX-cVsU)
- [La La Land - Mia & Sebastien's Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/La%20La%20Land%20-%20Mia%20%26%20Sebastians%20Theme%20(WIP)%20(Kyle%20Landrys%20Arr.).pdf) | [Youtube](https://www.youtube.com/watch?v=AX1S9sewz9I)
- [Joe Hisaishi - Howl's Moving Castle Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Joe%20Hisaishi/Howls%20Moving%20Castle%20Theme.pdf) | [Youtube](https://www.youtube.com/watch?v=puAuDt6aNsw)
- [Joe Hisaishi - Medley](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Joe%20Hisaishi/KL_Joe_Hisaishi_Medley_PAV.pdf) | [Youtube](https://www.youtube.com/watch?v=1LGaLDpBafQ)
- [Joe Hisaishi - Spirited Away (Inochi no Namae)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Joe%20Hisaishi/Inochi%20no%20Namae.pdf) | [Youtube](https://www.youtube.com/watch?v=-V68TPR7-jY)
- [Joe Hisaishi - Spirited Away (Waltz of Chihiro)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Joe%20Hisaishi/Waltz%20of%20Chihiro.pdf) | [Youtube](https://www.youtube.com/watch?v=ZgCWSQORT5k)
- [Joe Hisaishi - Castle In The Sky Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Joe%20Hisaishi/KL_Ghibli_Castle_in_the_Sky.pdf) | [Youtube](https://www.youtube.com/watch?v=dVdxEOZZrtI)
- [Amélie - Comptine d'un autre été](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Amelie%20-%20Comptine%20d'un%20autre%20%C3%A9t%C3%A9.pdf) | [Youtube](https://www.youtube.com/watch?v=flDDc3Ru38g)
- [Anastasia - Once Upon A December](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Anastasia%20-%20Once%20Upon%20A%20December.pdf) | [Youtube](https://www.youtube.com/watch?v=HpXHdegMTtw)
- [Braveheart Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Braveheart%20Theme.pdf) | [Youtube](https://www.youtube.com/watch?v=bo7Gh0n269E)
- [Les Misérables - I Dreamed A Dream](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Les%20Miserables%20-%20I%20Dreamed%20a%20Dream.pdf) | [Youtube](https://www.youtube.com/watch?v=0Wlrv-Pc8ko)
- [Secret - Time Travel Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Time%20Travel%20Theme.pdf) | [Youtube](https://www.youtube.com/watch?v=jg6oJjcGYVE)
- [Transformers - Arrival to Earth](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Transformers%20-%20Arrival%20to%20Earth.pdf) | [Youtube](https://www.youtube.com/watch?v=LjyviatSeCY)
- [Hans Zimmer - Pirates of The Caribbean Medley](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Hans%20Zimmer/Pirates%20of%20the%20Caribbean%20Medley.pdf) | [Youtube](https://www.youtube.com/watch?v=pidW3I9GQa8)
- [Hans Zimmer - Inception (Time)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Hans%20Zimmer/Inception%20-%20Time.pdf) | [Youtube](https://www.youtube.com/watch?v=JOtDS0vRwxg)
- [Hans Zimmer - Interstellar (First Step)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Hans%20Zimmer/Interstellar%20-%20FirstStep.pdf) | [Youtube](https://www.youtube.com/watch?v=h9vj-p1yGLw)
- [Lord Of The Rings Medley](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Howard%20Shore/Lord%20of%20the%20Rings%20Medley.pdf) | [Youtube](https://www.youtube.com/watch?v=mDY8jLYnL0I)
- [The Hobbit - Misty Mountains](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Howard%20Shore/Misty%20Mountains.pdf) | [Youtube](https://www.youtube.com/watch?v=Tn1Amt1A52Y)
- <a name="movies"></a> ***Movies*** |
- [Queen - Bohemian Raphsody](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Queen/Bohemian%20Rhapsody.pdf) | [Youtube](https://www.youtube.com/watch?v=ucot-V9WuxY)
- [Queen - We Are The Champions](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Queen/We%20Are%20The%20Champions.pdf) | [Youtube](https://www.youtube.com/watch?v=rJf5xVZWxcQ)
- [Adele - Skyfall](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Adele%20-%20Skyfall.pdf) | [Youtube](https://www.youtube.com/watch?v=uto95f62oWM)
- [Alphaville - Forever Young](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Alphaville%20-%20Forever%20Young.pdf) | [Youtube](https://www.youtube.com/watch?v=4ZO0n4zgfPw)
- [Boys Like Girls - The Great Escape](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Boys%20Like%20Girls%20-%20The%20Great%20Escape.pdf) | [Youtube](https://www.youtube.com/watch?v=fdZETb-ZVo4)
- [Daniel Powter - Bad Day](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Daniel%20Powter%20-%20Bad%20Day.pdf) | [Youtube](https://www.youtube.com/watch?v=GryaXGFCh0g)
- [Evanescence - My Immortal](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Evanescence%20-%20My%20Immortal.pdf) | [Youtube](https://www.youtube.com/watch?v=NRKHQOj1dGw)
- [GOTYE - Somebody That I Used to Know](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/GOTYE%20-%20Somebody%20That%20I%20Used%20to%20Know.pdf) | [Youtube](https://www.youtube.com/watch?v=X-Hog1jwVVs)
- [Guang Liang - Tong Hua Fairytale](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Guang%20Liang%20-%20Tong%20Hua%20Fairytale.pdf) | [Youtube](https://www.youtube.com/watch?v=EEzZkI6kxu0)
- [John Legend - All Of Me](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/John%20Legend%20-%20All%20Of%20Me.pdf) | [Youtube](https://www.youtube.com/watch?v=8F3cu7JGVrQ)
- [Josh Groban - You raise me up](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Josh%20Groban%20-%20You%20raise%20me%20up.pdf) | [Youtube](https://www.youtube.com/watch?v=uto95f62oWM)
- [Journey - Open Arms](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Journey%20-%20Open%20Arms.pdf) | [Youtube](https://www.youtube.com/watch?v=HoYURsJY6fY)
- [Leonard Cohen - Hallelujah](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Leonard%20Cohen%20-%20Hallelujah.pdf) | [Youtube](https://www.youtube.com/watch?v=TBMf3mcIGkw)
- [One Republic - Apologize](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/One%20Republic%20-%20Apologize.pdf) | [Youtube](https://www.youtube.com/watch?v=IAVIZe5lKow)
- [Richard Clayderman - Besame Mucho](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Richard%20Clayderman%20-%20Besame%20Mucho.pdf) | [Youtube](https://www.youtube.com/watch?v=heU7kt5jx8I)
- [Scarborough Fair](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Scarborough%20Fair.pdf) | [Youtube](https://www.youtube.com/watch?v=2OMFkTM5Mrs)
- [Taeyang - Wedding Dress](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Taeyang%20-%20Wedding%20Dress.pdf) | [Youtube](https://www.youtube.com/watch?v=CmhOlhF2X6s)
- [Train - Drops of Jupiter](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Train%20-%20Drops%20of%20Jupiter.pdf) | [Youtube](https://www.youtube.com/watch?v=7aXltwtw4w0)
+> All credits belong to their respective artists. Sheets were sourced from public sites such as Scribd, Musescore, free-scores, etc.
+>
+> This readme highlights key collections with curated YouTube links. For the complete file-by-file inventory, see **[tree.txt](https://github.com/JKleinne/PianoSheets/blob/master/tree.txt)**.
 
-### <a name="vkgoeswild"></a> Vika Yermalova (Vkgoeswild)
-Sheet | YouTube/Sample
- --- | --- 
- [Scorpions - Wind Of Change](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Wind%20of%20Change.pdf) | [Youtube](https://www.youtube.com/watch?v=fKBvaeSboNk)
- [Queen - Bohemian Raphsody.pdf](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Bohemian%20Raphsody.pdf) | [Youtube](https://www.youtube.com/watch?v=rptV6K7nqu0)
- [Queen - Who Wants To Live Forever](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Who%20wants%20to%20live%20forever.pdf) | [Youtube](https://www.youtube.com/watch?v=InbDWywMbfM) 
- [Queen - Somebody To Love](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Somebody%20to%20Love.pdf) | [Youtube](https://www.youtube.com/watch?v=XYrlrMtAB3M)
- [Coldplay - Clocks](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Clocks.pdf) | [Youtube](https://www.youtube.com/watch?v=fOop0dE8hQI)
- [Pink Floyd - Comfortably Numb](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Comfortably%20Numb.pdf) | [Youtube](https://www.youtube.com/watch?v=sq1TTCi9RVA)
- [Pink Floyd - Echoes](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Echoes.pdf) | [Youtube](https://www.youtube.com/watch?v=FI0fyOaD94Y)
- [Eagles - Hotel California](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Hotel%20California.pdf) | [Youtube](https://www.youtube.com/watch?v=Z3bxLL2eMYc)
- [Phil Collins - In The Air Tonight](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/In%20The%20Air%20Tonight.pdf) | [Youtube](https://www.youtube.com/watch?v=t_3S0mcNe08)
- [Guns N' Roses - Knocking on Heaven's Door](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Knocking%20on%20Heaven's%20Door.pdf) | [Youtube](https://www.youtube.com/watch?v=GiZDgdE8SUk)
- [Guns N' Roses - November Rain](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/November%20Rain.pdf) | [Youtube](https://www.youtube.com/watch?v=FhbeNEtkgDs) 
- [Guns N' Roses - Sweet Child o' Mine](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Sweet%20Child.pdf) | [Youtube](https://www.youtube.com/watch?v=ff8UwvPK0G4)
- [Guns N' Roses - This I love](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/This%20I%20Love.pdf) | [Youtube](https://www.youtube.com/watch?v=i6y0sK2vzd0)
- [Metallica - Nothing Else Matters](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Nothing%20Matters.pdf) | [Youtube](https://www.youtube.com/watch?v=Six5zn4oXGE)
- [Metallica - One](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Metallica%20-%20One.pdf) | [Youtube](https://www.youtube.com/watch?v=4_3whe5_G2g)
- [Extreme - More Than Words](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/More%20Than%20Words.pdf) | [Youtube](https://www.youtube.com/watch?v=R5KBk76b9HE)
- [Pantera - Cemetary Gates](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Pantera%20Cemetary%20Gates.pdf) | [Youtube](https://www.youtube.com/watch?v=Pl5KnzgDyDY)
- [The Pixies - Where Is My Mind](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Pixies%20where%20is%20my%20mind.pdf) | [Youtube](https://www.youtube.com/watch?v=KFiScXBMR7E)
- [Led Zeppelin - Stairway To Heaven](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Stairway%20to%20heaven.pdf) | [Youtube](https://www.youtube.com/watch?v=dwWmVLKdHPE)
+---
 
-### <a name="zohar"></a> Zohar
- Sheet | YouTube/Sample
- --- | --- 
- [Chrono Trigger - Secret of the Forest (1)](https://github.com/JKleinne/PianoSheets/blob/master/Zohar002/Chrono%20Trigger%20-%20Secret%20of%20the%20Forest.pdf) | [Youtube](https://www.youtube.com/watch?v=pLx6N98Y6RE)
- [Chrono Trigger - Secret of the Forest (2)](https://github.com/JKleinne/PianoSheets/blob/master/Zohar002/Chrono%20Trigger%20-%20Secret%20of%20the%20Forest%20(2).pdf) | [Youtube](https://www.youtube.com/watch?v=pLx6N98Y6RE) 
- [CEG](https://github.com/JKleinne/PianoSheets/blob/master/Zohar002/CEG.pdf) | [Youtube](https://www.youtube.com/watch?v=4ckc2BDOYvc)
- [Chrono Cross - Dimension Breach](https://github.com/JKleinne/PianoSheets/blob/master/Zohar002/Chrono%20Cross%20-%20Dimension%20Breach.pdf) | [Youtube](https://www.youtube.com/watch?v=kQ0ZZUXgswQ)
- [Chrono Trigger - Corridors of Time (1)](https://github.com/JKleinne/PianoSheets/blob/master/Zohar002/Chrono%20Trigger%20-%20Corridors%20of%20Time.pdf) | [Youtube](https://www.youtube.com/watch?v=kQ0ZZUXgswQ)
- [Chrono Trigger - Corridors of Time (2)](https://github.com/JKleinne/PianoSheets/blob/master/Zohar002/Chrono%20Trigger%20-%20Corridors%20of%20Time%20(2).pdf) | [Youtube](https://www.youtube.com/watch?v=kQ0ZZUXgswQ)
- [Chrono Trigger - Frog's Theme](https://github.com/JKleinne/PianoSheets/blob/master/Zohar002/Chrono%20Trigger%20-%20Frog's%20Theme.pdf) | [Youtube](https://www.youtube.com/watch?v=GjHFoptKNZU)
- [Chrono Trigger - Peaceful Days (1)](https://github.com/JKleinne/PianoSheets/blob/master/Zohar002/Chrono%20Trigger%20-%20Peaceful%20Days.pdf) | [Youtube](https://www.youtube.com/watch?v=9Ua3H3ylnv8)
- [Chrono Trigger - Peaceful Days (2)](https://github.com/JKleinne/PianoSheets/blob/master/Zohar002/Chrono%20Trigger%20-%20Peaceful%20Days%20(2).pdf) | [Youtube](https://www.youtube.com/watch?v=9Ua3H3ylnv8)
- [Chrono Trigger - Piano Medley](https://github.com/JKleinne/PianoSheets/blob/master/Zohar002/Chrono%20Trigger%20-%20Piano%20Medley.pdf) | 
- [Chrono Trigger - Schala's Theme](https://github.com/JKleinne/PianoSheets/blob/master/Zohar002/Chrono%20Trigger%20-%20Schala's%20Theme.pdf) | [Youtube](https://www.youtube.com/watch?v=FfIG0Tw0dnw)
- [Chrono Trigger - Singing Mountain](https://github.com/JKleinne/PianoSheets/blob/master/Zohar002/Chrono%20Trigger%20-%20Singing%20Mountain.pdf) | [Youtube](https://www.youtube.com/watch?v=j7B5wO5_omI)
- [Chrono Trigger - To Far Away Times](https://github.com/JKleinne/PianoSheets/blob/master/Zohar002/Chrono%20Trigger%20-%20To%20Far%20Away%20Times.pdf) | [Youtube](https://www.youtube.com/watch?v=x_4ndNoraV4)
- [Chrono Trigger - To Good Friends](https://github.com/JKleinne/PianoSheets/blob/master/Zohar002/Chrono%20Trigger%20-%20To%20Good%20Friends.pdf) | [Youtube](https://www.youtube.com/watch?v=SUk9ybSnMMo)
- [Chrono Trigger - Wind Scene](https://github.com/JKleinne/PianoSheets/blob/master/Zohar002/Chrono%20Trigger%20-%20Wind%20Scene.pdf) | [Youtube](https://www.youtube.com/watch?v=PY-lLrclanw)
- [Chrono Trigger - Wind Scene Paraphrase](https://github.com/JKleinne/PianoSheets/blob/master/Zohar002/Chrono%20Trigger%20-%20Wind%20Scene%20Paraphrase.pdf) | [Youtube](https://www.youtube.com/watch?v=_qJzDDTUk7E)
- [Chrono Trigger - World Revolution](https://github.com/JKleinne/PianoSheets/blob/master/Zohar002/Chrono%20Trigger%20-%20World%20Revolution.pdf) | [Youtube](https://www.youtube.com/watch?v=i25QnaxZSIo)
- [Final Fantasy VI - Aria di Mezzo Carattere](https://github.com/JKleinne/PianoSheets/blob/master/Zohar002/Final%20Fantasy%20VI%20-%20Aria%20di%20Mezzo%20Carattere.pdf) | [Youtube](https://www.youtube.com/watch?v=lKOB09qIqy4://www.youtube.com/watch?v=j7B5wO5_omI)
- [Saga Frontier - The Opening of a Journey](https://github.com/JKleinne/PianoSheets/blob/master/Zohar002/Saga%20Frontier%20-%20Opening.pdf) | [Youtube](https://www.youtube.com/watch?v=sEnc3JIzwSk)
- [Saga Frontier - Aserus Ending Theme](https://github.com/JKleinne/PianoSheets/blob/master/Zohar002/Saga%20Frontier%20-%20Aserus%20Ending%20Theme.pdf) | [Youtube](https://www.youtube.com/watch?v=7io75DIjEVs)
- [Xenogears - Shevat, The Wind is Calling](https://github.com/JKleinne/PianoSheets/blob/master/Zohar002/Xenogears%20-%20Shevat%2C%20The%20Wind%20is%20Calling.pdf) | [Youtube](https://www.youtube.com/watch?v=CUKBhBqlXzU)
+## At a Glance
 
-### <a name="jazz"></a> Jazz
- Sheet | YouTube/Sample
- --- | --- 
- [Dream A Little Dream Of Me (***as performed by Scott Bradlee***)](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Dream%20A%20Little%20Dream%20Of%20Me.pdf) | [Youtube](https://www.youtube.com/watch?v=7eC0FuYBKs8)
- [Autumn Leaves](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Autumn%20Leaves.pdf) | [Youtube](https://www.youtube.com/watch?v=OA3Hj7f6ChE)
- [La Vie En Rose](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/La%20Vie%20en%20Rose.pdf) | [Youtube](https://www.youtube.com/watch?v=hgsVsDo8V7Q)
- [Tenderly (***as performed by Art Tatum***)](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Art%20Tatum%20-%20Tenderly.pdf) | [Youtube](https://www.youtube.com/watch?v=meTBMQkcGhQ)
- <a name="jonny-may"></a> ***Jonny May*** |
- [Somewhere Over The Rainbow](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Jonny%20May/Somewhere%20Over%20The%20Rainbow.pdf) | [Youtube](https://www.youtube.com/watch?v=_7xsy6xgVh0)
- [Happy Birthday ***Jazz***](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Jonny%20May/Jazz%20Happy%20Birthday.pdf) | [Youtube](https://www.youtube.com/watch?v=4sZmPHJPvZE)
- [Cruella De Vil](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Jonny%20May/Cruella%20De%20Vil.pdf) | [Youtube](https://www.youtube.com/watch?v=IaMacRAJwTw)
- [Avicii - Wake Me Up](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Jonny%20May/Avicii%20-%20Wake%20Me%20Up.pdf) | [Youtube](https://www.youtube.com/watch?v=Bv0NDgCzl6U)
- <a name="hans-piano"></a> ***Hans Piano*** |
- [Blue Bossa](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/Blue%20Bossa.pdf) | [Youtube](https://www.youtube.com/watch?v=nU9W38VjZ4I)
- [The Carpenters - Close To You](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/The%20Carpenters%20-%20Close%20To%20You.pdf) | [Youtube](https://www.youtube.com/watch?v=jWvYtv0wrZE)
- [Bee Gees - How Deep Is Your Love](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/How%20Deep%20Is%20Your%20Love.pdf) | [Youtube](https://www.youtube.com/watch?v=65Xza4MayvM)
- [All of Me](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/All%20Of%20Me.pdf) | [Youtube](https://www.youtube.com/watch?v=-w51QfwLaho) 
- [Can't Take My Eyes Off You](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/Can't%20Take%20My%20Eyes%20Off%20You.pdf) | [Youtube](https://www.youtube.com/watch?v=1-EZUMCSwUc)   
- [Moon River](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/Moon%20River.pdf) | [Youtube](https://www.youtube.com/watch?v=AXPEmv6cUrk) 
- [Misty](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/Misty.pdf) | [Youtube](https://www.youtube.com/watch?v=cOKWJSfcWnE)
- [The Way You Look Tonight](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/The%20Way%20You%20Look%20Tonight.pdf) | [Youtube](https://www.youtube.com/watch?v=gtnXveHiKyo)
- [Unforgettable](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/Unforgettable.pdf) | [Youtube](https://www.youtube.com/watch?v=Dkw8K2s8s3k)
- [Christmas Medley](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/Christmas%20Medleys.pdf) | [Youtube](https://www.youtube.com/watch?v=Fd6DClQoL2k)
- [Fly Me To The Moon](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/Fly%20Me%20To%20The%20Moon.pdf) | [Youtube](https://www.youtube.com/watch?v=Z6U-8xF7e8A)
- [Just The Two Of Us](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/Just%2BTwo%2BOf%2BUs.pdf) | [Youtube](https://www.youtube.com/watch?v=0Ocl42QliEE)
- <a name="rpa"></a> ***Rupert Austin*** |
- [Misty](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Misty.pdf) | [Youtube](https://www.youtube.com/watch?v=vhRwSAbA-CQ)
- [Autumn Leaves](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Autumn%20Leaves.pdf) | [Youtube](https://www.youtube.com/watch?v=HQ_IUUtDJW8)
- [Somewhere Over The Rainbow](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Over%20the%20Rainbow.pdf) | [Youtube](https://www.youtube.com/watch?v=SEwqRF-_hsk)
- [A Time For Love](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_A%20Time%20For%20Love.pdf) | [Youtube](https://www.youtube.com/watch?v=SJUSt69mnN8)
- [Bewitched, Bothered and Bewildered](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Bewitched.pdf) | [Youtube](https://www.youtube.com/watch?v=mZOI4AGn0WM)
- [Close Enough For Love](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Close%20Enough%20For%20Love.pdf) | [Youtube](https://www.youtube.com/watch?v=aDSgd7E9KS4)
- [East of the Sun (and West of the Moon)](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_East%20of%20the%20Sun%20and%20West%20of%20the%20moon.pdf) | [Youtube](https://www.youtube.com/watch?v=TzA_vXbJG8g)
- [How Deep Is The Ocean](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_How%20Deep%20Is%20The%20Ocean.pdf) | [Youtube](https://www.youtube.com/watch?v=O51RLWnXjvM)
- [I Remember You](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_I%20Remember%20You.pdf) | [Youtube](https://www.youtube.com/watch?v=IXMqhKqLhyU)
- [Love Letters (Straight From Your Heart)](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Love%20Letters.pdf) | [Youtube](https://www.youtube.com/watch?v=Sq1e0lJLVvQ)
- [On Green Dolphin Street](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_On%20Green%20Dolphin%20Street.pdf) | [Youtube](https://www.youtube.com/watch?v=xm3yuGM5kFk)
- [On A Clear Day (You Can See Forever)](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_On%20a%20Clear%20Day.pdf) | [Youtube](https://www.youtube.com/watch?v=m18MT0wTk-4)
- [Polka Dots and Moonbeams](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Polka%20Dots%20and%20Moonbeams.pdf) | [Youtube](https://www.youtube.com/watch?v=PjyYO5QWDgI)
- [Softly As In A Morning Sunrise](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Softly%20as%20in%20a%20Morning%20Sunrise.pdf) | [Youtube](https://www.youtube.com/watch?v=MX7onUERjwY)
- [Someone To Watch Over Me](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Someone%20To%20Watch%20Over%20Me.pdf) | [Youtube](https://www.youtube.com/watch?v=JGIuAO1auI8)
- [Stella By Starlight](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Stella%20By%20Starlight.pdf) | [Youtube](https://www.youtube.com/watch?v=S_ndumRgcNM)
- [Summertime](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Summertime.pdf) | [Youtube](https://www.youtube.com/watch?v=obC5waiXlIQ)
- ---
+| Collection | Sheets | Highlights |
+|---|--:|---|
+| [Classical](#classical) | 511 | Bach, Beethoven, Chopin, Mozart, Rachmaninov |
+| [Mercuziopianist](#mercuziopianist) | 548 | Film scores and classical arrangements |
+| [Yiruma](#yiruma) | 172 | Complete works across multiple albums |
+| [Kyle Landry](#kyle-landry) | 141 | Anime, Disney, Games, Movies, Songs |
+| [Video Games](#video-games) | 76 | Final Fantasy Piano Collections, Zohar002 |
+| [Jazz](#jazz) | 46 | Hans Piano, RPA (Rupert Austin) |
+| [Vika Yermalova](#vika-yermalova-vkgoeswild) | 20 | Rock/pop piano adaptations |
+| [Misc](#misc) | 20 | Uncategorized pieces |
+| [Personal Favorites](#personal-favorites) | 18 | Curated cross-genre selection |
+| [richard-clayderman](#richard-clayderman) | 6 | Romantic piano arrangements |
+| [Collections](#collections) | 2 | Bound multi-piece volumes |
+| [Beethoven Virus](#beethoven-virus) | 2 | Allegro + Jazz arrangement |
+| **Total** | **1,583** | |
+
+---
+
+## Table of Contents
+
+- [Classical](#classical) — Bach, Beethoven, Chopin, Mozart, Rachmaninov
+- [Mercuziopianist](#mercuziopianist)
+- [Yiruma](#yiruma)
+- [Kyle Landry](#kyle-landry) — [Anime](#anime) · [Christmas](#christmas) · [Disney](#disney) · [Games](#games) · [Movies](#movies) · [Songs](#songs)
+- [Video Games](#video-games) — [Final Fantasy](#final-fantasy-piano-collections) · [Zohar002](#zohar002)
+- [Jazz](#jazz) — [Hans Piano](#hans-piano) · [RPA (Rupert Austin)](#rpa-rupert-austin)
+- [Vika Yermalova (Vkgoeswild)](#vika-yermalova-vkgoeswild)
+- [Other Collections](#other-collections) — [Personal Favorites](#personal-favorites) · [Misc](#misc) · [richard-clayderman](#richard-clayderman) · [Collections](#collections) · [Beethoven Virus](#beethoven-virus)
+
+---
+
+## Classical
+
+**511 sheets** spanning five major composers, plus standalone works. Organized by composer and then by work type. All files are in the `Classical/` directory.
+
+### Bach, JS — 160 sheets
+
+| Category | Files | Notes |
+|---|--:|---|
+| The Well-Tempered Clavier I | 24 | Preludes & Fugues 1–24 |
+| The Well-Tempered Clavier II | 24 | Preludes & Fugues 1–24 |
+| Preludes, Fantasias, Fugues | 44 | Chromatic Fantasia & Fugue, individual fugues, preludes |
+| 6 English Suites | 6 | BWV 806–811 |
+| 6 French Suites | 6 | BWV 812–817 |
+| 6 Partitas | 6 | Nos. 1–6 |
+| 7 Toccatas | 7 | BWV 910–916 |
+| Suites, Concertos, Capriccios, Overtures | 10 | Italian Concerto, Overture in French Style, etc. |
+| Other | 10 | Minuets, Notebook for AM Bach, Gavotte, etc. |
+| Sonatas, Partitas | 7 | BWV 832, 963–966, 997, 1006a |
+| 6 Brandenburg Concertos (4 Hands) | 6 | Nos. 1–6 |
+| 371 Four-Part Chorales | 4 | In 4 volumes |
+| Inventions & Sinfonias | 2 | 15 Inventions + 15 Sinfonias |
+| The Art of the Fugue | 2 | In 2 parts |
+| Goldberg Variations | 1 | BWV 988 |
+| The Musical Offering | 1 | |
+
+### Beethoven — 124 sheets
+
+| Category | Files | Notes |
+|---|--:|---|
+| Sonatas | 32 | Complete 32 Piano Sonatas |
+| Other | 31 | Dances, Rondos, Ecossaises, Polonaise, Fantasia, etc. |
+| Variations | 20 | Including Diabelli & Eroica Variations |
+| Quartets arr. for Solo Piano | 17 | Opp. 18, 59, 74, 95, 127–135 + Grosse Fuge |
+| Piano with Orchestra | 15 | 5 Concertos (2-piano red.), Triple Concerto, Choral Fantasy, 8 Cadenzas |
+| Bagatelles | 6 | Opp. 33, 119, 126, Für Elise, WoO 54, 60 |
+| Sonatinas | 6 | In C, D, Eb, F, f, G |
+| 4 Hands | 5 | Marches, Variations, Grosse Fuge, Sonata Op. 6 |
+
+*Note: Cadenzas are in `Piano with Orchestra/Cadenzas/` for Concertos 1–4.*
+
+### Chopin — 88 sheets
+
+| Category | Files | Notes |
+|---|--:|---|
+| Other | 16 | Barcarole, Berceuse, Bolero, Fantasy in f, Tarantelle, etc. |
+| Mazurkas | 14 | Opp. 6, 7, 17, 24, 30, 33, 41, 50, 56, 59, 63, 67, 68, + posthumous |
+| Nocturnes | 11 | Opp. 9, 15, 27, 32, 37, 48, 55, 62, 72 + posthumous |
+| Polonaises | 9 | Opp. 26, 40, 44, 53, 61, 71 + posthumous |
+| Piano with Orchestra | 8 | 2 Concertos (solo + 2-piano), Grand Fantaisie, Grand Polonaise, etc. |
+| Waltzes | 7 | Opp. 18, 34, 42, 64, 69, 70 + posthumous |
+| Ballades | 4 | Nos. 1–4 (Opp. 23, 38, 47, 52) |
+| Impromptus | 4 | Nos. 1–3 + Fantaisie-Impromptu |
+| Scherzos | 4 | Nos. 1–4 (Opp. 20, 31, 39, 54) |
+| Etudes | 3 | Op. 10, Op. 25, Trois Nouvelles Études |
+| Rondos | 3 | Op. 1, 5, 16 |
+| Sonatas | 3 | Nos. 1–3 (Opp. 4, 35, 58) |
+| Preludes | 2 | 24 Preludes Op. 28 + Op. 45 |
+
+### Mozart — 114 sheets
+
+| Category | Files | Notes |
+|---|--:|---|
+| Other | 34 | Minuets, Rondos, Fugues, Allegros, German Dances, etc. |
+| Piano with Orchestra | 29 | 27 Concertos (2-piano red.) + Rondo K. 382 + 12 Cadenza sets |
+| Sonatas | 19 | Complete 19 Piano Sonatas |
+| Variations | 17 | Including "Ah! Vous dirai-je, Maman" K. 265 |
+| 4 Hands | 10 | Sonatas, Fugue, Fantasy, Theme & Variations |
+| Fantasies | 3 | K. 394, 396, 397 |
+| 2 Piano | 3 | Sonata K. 448, Adagio K. 426, Fugue K. 426 |
+
+*Note: Cadenzas are in `Piano with Orchestra/Cadenzas/` for select Concertos.*
+
+### Rachmaninov — 19 sheets
+
+| Category | Files | Notes |
+|---|--:|---|
+| Other | 5 | 5 Fantasy Pieces, 6 Moments Musicaux, 7 Morceaux de Salon, Romance, Chopin Variations |
+| Piano with Orchestra | 4 | 3 Concertos + Rhapsody on a Theme of Paganini (2-piano red.) |
+| Sonatas | 3 | No. 1, No. 2 (original + revised) |
+| Etudes Tableaux | 2 | Op. 33 (8 études), Op. 39 (9 études) |
+| Preludes | 2 | 10 Preludes Op. 23, 13 Preludes Op. 32 |
+| 2 Piano | 2 | Suites Nos. 1 & 2 |
+| 4 Hands | 1 | 6 Pieces Op. 11 |
+
+### Standalone Works
+
+- Glinka — The Lark (A Farewell to St. Petersburg)
+- Liszt + Paganini — Étude VI (Capriccio No. 24)
+- Mozart–Liszt — Lacrimosa
+- Mozart–Thalberg — Lacrimosa
+- Vittorio Monti — Czárdás
+- Vivaldi — Winter
+
+---
+
+## Mercuziopianist
+
+**548 sheets** — the largest single collection in this repository. A flat directory of film score transcriptions and classical arrangements by the YouTube pianist [Mercuziopianist](https://www.youtube.com/user/Mercuziopianist).
+
+Covers an enormous range of composers and films, including works by Ennio Morricone, Nino Rota, Hans Zimmer, Dario Marianelli, Alexandre Desplat, Joe Hisaishi, Tchaikovsky, and many more. Notable entries include scores from *La La Land*, *Cinema Paradiso*, *The Godfather*, *Amélie*, *Schindler's List*, *Anna Karenina*, and *Braveheart*, alongside Italian pop/classical crossover pieces.
+
+> Due to the size of this collection (548 files), individual listings are not included here. See [tree.txt](https://github.com/JKleinne/PianoSheets/blob/master/tree.txt) for the full inventory.
+
+---
+
+## Yiruma
+
+**172 sheets** spanning Yiruma's complete discography, including albums *First Love*, *Love Scene*, *Nocturnal Lights... They Scatter*, *Oasis & Yiruma*, and *Reminiscent*. Features iconic pieces like *River Flows in You*, *Kiss the Rain*, *Maybe*, *Dream*, *Spring Waltz*, *When the Love Falls*, and *Destiny of Love*.
+
+Some files are in `.ove` format (Overture notation software) alongside their PDF counterparts. Many pieces appear in both album-grouped and standalone versions.
+
+> See [tree.txt](https://github.com/JKleinne/PianoSheets/blob/master/tree.txt) for the full inventory.
+
+---
+
+## Kyle Landry
+
+**141 sheets** of arrangements by the YouTube pianist [Kyle Landry](https://www.youtube.com/user/kylelandry), organized into 6 subcategories plus root-level pieces. Each section below contains curated entries with YouTube performance links.
+
+Sheet | YouTube
+--- | ---
+[Game Of Thrones Medley](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Game%20Of%20Thrones.pdf) | [YouTube](https://www.youtube.com/watch?v=NIVfy1V-_n0)
+[River Flows In You](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/River%20flows%20in%20you.pdf) | [YouTube](https://www.youtube.com/watch?v=qFwWE_flqcI)
+[SKY - Forever](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Sky%20-%20Forever.pdf) | [YouTube](https://www.youtube.com/watch?v=CsUu0qknxW8)
+
+### Anime
+
+<details>
+<summary>17 sheets — Naruto, One Piece, SAO, Clannad, Fairy Tail, and more</summary>
+
+Sheet | YouTube
+--- | ---
+[Pokemon - Gotta Catch 'Em All](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Pokemon%20-%20Gotta%20catch%20'em%20all.pdf) | [YouTube](https://www.youtube.com/watch?v=vZ3gPXVMWRY)
+[Fairy Tail - Main Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Fairy%20Tail%20Theme.pdf) | [YouTube](https://www.youtube.com/watch?v=dIqpUqwlWN4)
+[One Piece - Eyecatcher](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/One%20Piece/One%20Piece%20-%20Eyecatcher.pdf) | [YouTube](https://www.youtube.com/watch?v=HV8UbEbA2hk)
+[One Piece - Gold and Oden](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/One%20Piece/One%20Piece%20-%20Gold%20and%20Oden.pdf) | [YouTube](https://www.youtube.com/watch?v=HV8UbEbA2hk)
+[Naruto - Medley Special (Wind - Hokage Funeral - Sadness and Sorrow)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Naruto/Medley%20Special.pdf) | [YouTube](https://www.youtube.com/watch?v=ntkRQCh8c_Y)
+[Naruto - Alone](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Naruto/Alone.pdf) | [YouTube](https://www.youtube.com/watch?v=irEIwQBGKpg)
+[Naruto - Hinata vs Neji](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Naruto/Hinata%20VS%20Neji.pdf) | [YouTube](https://www.youtube.com/watch?v=X0qI66ix-QY)
+[Sword Art Online - Main Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Sword%20Art%20Online/SAO%20Main%20Theme.pdf) | [YouTube](https://www.youtube.com/watch?v=XzGl9B_cKOw)
+[Sword Art Online - Crossing Field](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Sword%20Art%20Online/Sword%20Art%20Online%20OP%20-%20Crossing%20Field.pdf) | [YouTube](https://www.youtube.com/watch?v=kGeQTdl7P1Q)
+[Kimi ni Todoke - Opening Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Kimi%20ni%20Todoke/Opening%20Theme.pdf) | [YouTube](https://www.youtube.com/watch?v=QQUiBgURdDM)
+[Kimi ni Todoke - Ending Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Kimi%20ni%20Todoke/Kataomoi.pdf) | [YouTube](https://www.youtube.com/watch?v=Vurr59c29Wo&t=2s)
+[Clannad - Dango Daikazoku](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Clannad%20-%20Dango%20Daikazoku.pdf) | [YouTube](https://www.youtube.com/watch?v=SlgNA49E7lI)
+[Elfen Lied - Lilium](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Elfen%20Lied%20-%20Lilium.pdf) | [YouTube](https://www.youtube.com/watch?v=sjXxCr_E1So)
+[Fate/Stay Night - Anata Ga Ita Mori](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Fate_Stay%20Night%20-%20Anata%20Ga%20Ita%20Mori.pdf) | [YouTube](https://www.youtube.com/watch?v=YzrrnLN3tF8)
+[Inuyasha - Every Heart](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Inu%20Yasha%20-%20Every%20Heart.pdf) | [YouTube](https://www.youtube.com/watch?v=IwTbRTIK2mQ)
+[Nodame Cantabile - Allegro Cantabile](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Nodame%20Cantabile%20OP%20-%20Allegro%20Cantabile.pdf) | [YouTube](https://www.youtube.com/watch?v=v5v3v4bWXGE)
+[Wolf's Rain - Gravity](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Anime/Wolfs%20Rain%20-%20Gravity.pdf) | [YouTube](https://www.youtube.com/watch?v=6RLgoQ0Pk7o)
+
+</details>
+
+### Christmas
+
+<details>
+<summary>5 sheets</summary>
+
+Sheet | YouTube
+--- | ---
+[Christmas Carol Medley](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Christmas/Christmas%20Carol%20Medley.pdf) | [YouTube](https://www.youtube.com/watch?v=pY7xGIGEch4)
+[Christmas Medley Special](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Christmas/Christmas%20Medley%20Special.pdf) | [YouTube](https://www.youtube.com/watch?v=GGBzsRFoCgA)
+[Jingle Bells / Sleigh Ride](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Christmas/Jingle%20Bells%2BSleigh%20Ride.pdf) | [YouTube](https://www.youtube.com/watch?v=pirei3xYidA)
+[Joy to the World](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Christmas/Joy%20to%20the%20World.pdf) | [YouTube](https://www.youtube.com/watch?v=0UTJhzvhHSU)
+[Silent Night](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Christmas/Silent%20Night.pdf) | [YouTube](https://www.youtube.com/watch?v=mOhuiezfxT4)
+
+</details>
+
+### Disney
+
+<details>
+<summary>20 sheets — Lion King, Beauty and the Beast, Mulan, Frozen, and more</summary>
+
+Sheet | YouTube
+--- | ---
+[Beauty and the Beast - Main Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Beauty%20and%20the%20Beast/Beauty%20and%20the%20Beast.pdf) | [YouTube](https://www.youtube.com/watch?v=AyhPxrchntM)
+[Beauty and the Beast - Be Our Guest](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Beauty%20and%20the%20Beast/Be%20Our%20Guest.pdf) | [YouTube](https://www.youtube.com/watch?v=vu2W2W8beRg)
+[Beauty and the Beast - Something There](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Beauty%20and%20the%20Beast/Something%20There.pdf) | [YouTube](https://www.youtube.com/watch?v=mfhM2y1aV48)
+[Mulan - Reflection](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Mulan/Reflection.pdf) | [YouTube](https://www.youtube.com/watch?v=A0OXk5BC350)
+[Mulan - I'll Make a Man Out of You](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Mulan/I'll%20Make%20a%20Man%20Out%20of%20You.pdf) | [YouTube](https://www.youtube.com/watch?v=OkP0XYvGBfs)
+[The Lion King - Can You Feel The Love Tonight](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/The%20Lion%20King/Can%20you%20feel%20the%20love%20tonight.pdf) | [YouTube](https://www.youtube.com/watch?v=9QG6vY2dYQE)
+[The Lion King - Circle of Life](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/The%20Lion%20King/Circle%20of%20Life.pdf) | [YouTube](https://www.youtube.com/watch?v=V_xdoMWLyS8)
+[The Lion King - King Of Pride Rock](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/The%20Lion%20King/King%20of%20Pride%20Rock.pdf) | [YouTube](https://www.youtube.com/watch?v=jJsiB3BuNIw)
+[The Lion King - This Land](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/The%20Lion%20King/This%20Land.pdf) | [YouTube](https://www.youtube.com/watch?v=_w4DBpxOx_s)
+[Aladdin - A Whole New World](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Aladdin%20-%20A%20Whole%20New%20World.pdf) | [YouTube](https://www.youtube.com/watch?v=BxTA6wn4qzI)
+[Enchanted - So Close](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Enchanted%20-%20So%20Close.pdf) | [YouTube](https://www.youtube.com/watch?v=41WJ6jD3EtQ)
+[Frozen - Let It Go](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Frozen%20-%20Let%20it%20go.pdf) | [YouTube](https://www.youtube.com/watch?v=tBAQd2v-_J4)
+[Hercules - I Can Go The Distance](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Hercules%20-%20I%20Can%20Go%20The%20Distance.pdf) | [YouTube](https://www.youtube.com/watch?v=pUIhted5gEE)
+[The Little Mermaid - Part Of Your World](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Part%20of%20Your%20World.pdf) | [YouTube](https://www.youtube.com/watch?v=_1ikn2ZYC5Q)
+[Pinocchio - When You Wish Upon A Star](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Pinocchio%20-%20When%20You%20Wish%20Upon%20A%20Star.pdf) | [YouTube](https://www.youtube.com/watch?v=GmVlJaFUnqQ)
+[Up - Married Life](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Pixar's%20Up%20-%20Married%20Life.pdf) | [YouTube](https://www.youtube.com/watch?v=fnyEi4qeuAk)
+[Pocahontas - Colors Of The Wind](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Pocahontas%20-%20Colors%20of%20The%20Wind.pdf) | [YouTube](https://www.youtube.com/watch?v=s1ERVXHNSJQ)
+[Tangled - I See The Light](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Tangled%20-%20I%20See%20The%20Light.pdf) | [YouTube](https://www.youtube.com/watch?v=UH6u0109yzo)
+[Tarzan - You'll Be In My Heart](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/Tarzan%20-%20You'll%20Be%20In%20My%20Heart.pdf) | [YouTube](https://www.youtube.com/watch?v=93T1BdwkCY8)
+[The Hunchback Of Notre-Dame - God Help The Outcasts](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Disney/The%20Hunchback%20of%20Notre-Dame%20-%20God%20Help%20The%20Outcasts.pdf) | [YouTube](https://www.youtube.com/watch?v=frlLFFHrhF4)
+
+</details>
+
+### Games
+
+<details>
+<summary>39 sheets — Kingdom Hearts, Final Fantasy, Zelda, Mario, Pokemon, and more</summary>
+
+Sheet | YouTube
+--- | ---
+[League of Legends - Summoners Call](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/League%20of%20Legends%20-%20Summoners%20Call.pdf) | [YouTube](https://www.youtube.com/watch?v=86uO4rXgtJc)
+[Skyrim - Main Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Skyrim%20-%20Main%20Theme.pdf) | [YouTube](https://www.youtube.com/watch?v=gkDCQcP89_Y)
+[Chrono Trigger - Yearnings Of The Wind (600 AD)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Chrono%20Trigger%20-%20Yearnings%20Of%20The%20Wind.pdf) | [YouTube](https://www.youtube.com/watch?v=V1pgSY48mgE)
+[Chrono Cross - Scars of Time](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Chrono%20Cross%20-%20Scars%20Of%20Time.pdf) | [YouTube](https://www.youtube.com/watch?v=x49UCaNqhKw)
+[Halo 3 - Never Forget](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Halo%203%20-%20Never%20Forget.pdf) | [YouTube](https://www.youtube.com/watch?v=ZJZrmEEbFxo)
+[Final Fantasy - Aerith's Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Final%20Fantasy/Aeriths%20Theme.pdf) | [YouTube](https://www.youtube.com/watch?v=d_0QkFBtQxQ)
+[Final Fantasy - 1000 Words](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Final%20Fantasy/1000%20Words.pdf) | [YouTube](https://www.youtube.com/watch?v=J4AVo_6OuNI)
+[Final Fantasy - Eternity (Memory Of Light And Waves)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Final%20Fantasy/Eternity%20(Memory%20of%20Lightwaves).pdf) | [YouTube](https://www.youtube.com/watch?v=vTMyGACAGe8)
+[Final Fantasy - To Zanarkand](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Final%20Fantasy/To%20Zanarkand.pdf) | [YouTube](https://www.youtube.com/watch?v=yPnu4eyAq2A)
+[Final Fantasy - Terra's Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Final%20Fantasy/Terras%20Theme.pdf) | [YouTube](https://www.youtube.com/watch?v=IJELF5oFl0Q)
+[Kingdom Hearts - Dearly Beloved (2008)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Kingdom%20Hearts/Dearly%20Beloved%20(2008).pdf) | [YouTube](https://www.youtube.com/watch?v=a4-sqvJRm5U)
+[Kingdom Hearts - Dearly Beloved (2009)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Kingdom%20Hearts/Dearly%20Beloved%20(2009).pdf) | [YouTube](https://www.youtube.com/watch?v=-FgYwY5F5P4)
+[Kingdom Hearts - Dearly Beloved (2010)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Kingdom%20Hearts/Dearly%20Beloved%20(2010).pdf) | [YouTube](https://www.youtube.com/watch?v=eQ0E3dsHRV4)
+[Kingdom Hearts - Dearly Beloved (2012)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Kingdom%20Hearts/Dearly%20Beloved%20(2012).pdf) | [YouTube](https://www.youtube.com/watch?v=6Ujdk26C7JA)
+[Kingdom Hearts - Dearly Beloved (2013)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Kingdom%20Hearts/Dearly%20Beloved%20(2013).pdf) | [YouTube](https://www.youtube.com/watch?v=bItsQnOxds0)
+[Kingdom Hearts - Dearly Beloved (Soft Edition)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Kingdom%20Hearts/Dearly%20Beloved%20(Soft%20Edition).pdf) | [YouTube](https://www.youtube.com/watch?v=Cg-EzLwC83A)
+[Kingdom Hearts - Hikari](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Kingdom%20Hearts/Hikari.pdf) | [YouTube](https://www.youtube.com/watch?v=YUOYZbDhfos)
+[Kingdom Hearts - Kairi](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Kingdom%20Hearts/Kairi.pdf) | [YouTube](https://www.youtube.com/watch?v=3ZvmFFrPGQM)
+[Kingdom Hearts - Passion](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Kingdom%20Hearts/Passion.pdf) | [YouTube](https://www.youtube.com/watch?v=-neZL4_O6sQ)
+[Mario - Super Mario World Castle Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Mario/Super%20Mario%20World%20Castle%20Theme.pdf) | [YouTube](https://www.youtube.com/watch?v=w9rI3Vf-qPI)
+[Mario - Super Mario 64 Dire Dire Docks](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Mario/Dire%20Dire%20Docks.pdf) | [YouTube](https://www.youtube.com/watch?v=80eFXnb9Uro)
+[Mario - Super Mario Galaxy Rosalina's Observatory](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Mario/Rosalinas%20Observatory.pdf) | [YouTube](https://www.youtube.com/watch?v=dd0vGfL4hgw)
+[Mario - Super Mario Brothers 2 Overworld Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Mario/Super%20Mario%20Overworld%20Theme.pdf) | [YouTube](https://www.youtube.com/watch?v=fej_4T8wmEE)
+[Mario - Super Mario RPG Mallow Finds Out He Is Not A Tadpole (Sad Song)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Mario/Super%20Mario%20RPG%20-%20Mallow%20Finds%20Out%20He%20Is%20Not%20A%20Tadpole.pdf) | [YouTube](https://www.youtube.com/watch?v=MycyQKZSg2M)
+[Pokemon - Medley](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Pokemon/Pokemon%20Medley.pdf) | [YouTube](https://www.youtube.com/watch?v=tOYIbV5y7FI)
+[Pokemon - Elite Four](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Pokemon/Elite%20Four.pdf) | [YouTube](https://www.youtube.com/watch?v=vWXtr3MRms0)
+[Pokemon - Ruby/Sapphire Ending Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Pokemon/Pokemon%20Ruby%20And%20Sapphire%20Ending%20Theme.pdf) | [YouTube](https://www.youtube.com/watch?v=_4VZgQiKbns)
+[The Legend of Zelda - Medley](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Zelda/Zelda%20Medley%20-%20Full%20Score.pdf) | [YouTube](https://www.youtube.com/watch?v=3p3MhflI8WQ)
+[The Legend of Zelda - Gerudo Valley](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Zelda/Gerudo%20Valley.pdf) | [YouTube](https://www.youtube.com/watch?v=QkC6mZa9Jrc)
+[The Legend of Zelda - Gerudo Valley (2013)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Zelda/Gerudo%20Valley%20(2013).pdf) | [YouTube](https://www.youtube.com/watch?v=lYLrPbngWHw)
+[The Legend of Zelda - Overworld Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Zelda/Overworld%20Theme.pdf) | [YouTube](https://www.youtube.com/watch?v=QwR_xbzVOvM)
+[The Legend of Zelda - Song Of Healing](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Games/Zelda/Song%20of%20Healing.pdf) | [YouTube](https://www.youtube.com/watch?v=LUq49NecOeE)
+
+</details>
+
+### Movies
+
+<details>
+<summary>34 sheets — Joe Hisaishi, Hans Zimmer, Harry Potter, Lord of the Rings, and more</summary>
+
+Sheet | YouTube
+--- | ---
+[Harry Potter - Medley](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Harry%20Potter/Hedwig's%20Theme.pdf) | [YouTube](https://www.youtube.com/watch?v=NzAXLX-cVsU)
+[La La Land - Mia & Sebastien's Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/La%20La%20Land%20-%20Mia%20%26%20Sebastians%20Theme%20(WIP)%20(Kyle%20Landrys%20Arr.).pdf) | [YouTube](https://www.youtube.com/watch?v=AX1S9sewz9I)
+[Joe Hisaishi - Howl's Moving Castle Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Joe%20Hisaishi/Howls%20Moving%20Castle%20Theme.pdf) | [YouTube](https://www.youtube.com/watch?v=puAuDt6aNsw)
+[Joe Hisaishi - Medley](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Joe%20Hisaishi/KL_Joe_Hisaishi_Medley_PAV.pdf) | [YouTube](https://www.youtube.com/watch?v=1LGaLDpBafQ)
+[Joe Hisaishi - Spirited Away (Inochi no Namae)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Joe%20Hisaishi/Inochi%20no%20Namae.pdf) | [YouTube](https://www.youtube.com/watch?v=-V68TPR7-jY)
+[Joe Hisaishi - Spirited Away (Waltz of Chihiro)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Joe%20Hisaishi/Waltz%20of%20Chihiro.pdf) | [YouTube](https://www.youtube.com/watch?v=ZgCWSQORT5k)
+[Joe Hisaishi - Castle In The Sky Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Joe%20Hisaishi/KL_Ghibli_Castle_in_the_Sky.pdf) | [YouTube](https://www.youtube.com/watch?v=dVdxEOZZrtI)
+[Amelie - Comptine d'un autre ete](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Amelie%20-%20Comptine%20d'un%20autre%20%C3%A9t%C3%A9.pdf) | [YouTube](https://www.youtube.com/watch?v=flDDc3Ru38g)
+[Anastasia - Once Upon A December](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Anastasia%20-%20Once%20Upon%20A%20December.pdf) | [YouTube](https://www.youtube.com/watch?v=HpXHdegMTtw)
+[Braveheart Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Braveheart%20Theme.pdf) | [YouTube](https://www.youtube.com/watch?v=bo7Gh0n269E)
+[Les Miserables - I Dreamed A Dream](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Les%20Miserables%20-%20I%20Dreamed%20a%20Dream.pdf) | [YouTube](https://www.youtube.com/watch?v=0Wlrv-Pc8ko)
+[Secret - Time Travel Theme](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Time%20Travel%20Theme.pdf) | [YouTube](https://www.youtube.com/watch?v=jg6oJjcGYVE)
+[Transformers - Arrival to Earth](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Transformers%20-%20Arrival%20to%20Earth.pdf) | [YouTube](https://www.youtube.com/watch?v=LjyviatSeCY)
+[Hans Zimmer - Pirates of The Caribbean Medley](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Hans%20Zimmer/Pirates%20of%20the%20Caribbean%20Medley.pdf) | [YouTube](https://www.youtube.com/watch?v=pidW3I9GQa8)
+[Hans Zimmer - Inception (Time)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Hans%20Zimmer/Inception%20-%20Time.pdf) | [YouTube](https://www.youtube.com/watch?v=JOtDS0vRwxg)
+[Hans Zimmer - Interstellar (First Step)](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Hans%20Zimmer/Interstellar%20-%20FirstStep.pdf) | [YouTube](https://www.youtube.com/watch?v=h9vj-p1yGLw)
+[Lord Of The Rings Medley](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Howard%20Shore/Lord%20of%20the%20Rings%20Medley.pdf) | [YouTube](https://www.youtube.com/watch?v=mDY8jLYnL0I)
+[The Hobbit - Misty Mountains](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Movies/Howard%20Shore/Misty%20Mountains.pdf) | [YouTube](https://www.youtube.com/watch?v=Tn1Amt1A52Y)
+
+</details>
+
+### Songs
+
+<details>
+<summary>21 sheets — Queen, Adele, Evanescence, John Legend, and more</summary>
+
+Sheet | YouTube
+--- | ---
+[Queen - Bohemian Rhapsody](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Queen/Bohemian%20Rhapsody.pdf) | [YouTube](https://www.youtube.com/watch?v=ucot-V9WuxY)
+[Queen - We Are The Champions](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Queen/We%20Are%20The%20Champions.pdf) | [YouTube](https://www.youtube.com/watch?v=rJf5xVZWxcQ)
+[Adele - Skyfall](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Adele%20-%20Skyfall.pdf) | [YouTube](https://www.youtube.com/watch?v=uto95f62oWM)
+[Alphaville - Forever Young](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Alphaville%20-%20Forever%20Young.pdf) | [YouTube](https://www.youtube.com/watch?v=4ZO0n4zgfPw)
+[Boys Like Girls - The Great Escape](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Boys%20Like%20Girls%20-%20The%20Great%20Escape.pdf) | [YouTube](https://www.youtube.com/watch?v=fdZETb-ZVo4)
+[Daniel Powter - Bad Day](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Daniel%20Powter%20-%20Bad%20Day.pdf) | [YouTube](https://www.youtube.com/watch?v=GryaXGFCh0g)
+[Evanescence - My Immortal](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Evanescence%20-%20My%20Immortal.pdf) | [YouTube](https://www.youtube.com/watch?v=NRKHQOj1dGw)
+[GOTYE - Somebody That I Used to Know](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/GOTYE%20-%20Somebody%20That%20I%20Used%20to%20Know.pdf) | [YouTube](https://www.youtube.com/watch?v=X-Hog1jwVVs)
+[Guang Liang - Tong Hua Fairytale](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Guang%20Liang%20-%20Tong%20Hua%20Fairytale.pdf) | [YouTube](https://www.youtube.com/watch?v=EEzZkI6kxu0)
+[John Legend - All Of Me](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/John%20Legend%20-%20All%20Of%20Me.pdf) | [YouTube](https://www.youtube.com/watch?v=8F3cu7JGVrQ)
+[Josh Groban - You Raise Me Up](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Josh%20Groban%20-%20You%20raise%20me%20up.pdf) | [YouTube](https://www.youtube.com/watch?v=uto95f62oWM)
+[Journey - Open Arms](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Journey%20-%20Open%20Arms.pdf) | [YouTube](https://www.youtube.com/watch?v=HoYURsJY6fY)
+[Leonard Cohen - Hallelujah](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Leonard%20Cohen%20-%20Hallelujah.pdf) | [YouTube](https://www.youtube.com/watch?v=TBMf3mcIGkw)
+[One Republic - Apologize](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/One%20Republic%20-%20Apologize.pdf) | [YouTube](https://www.youtube.com/watch?v=IAVIZe5lKow)
+[Richard Clayderman - Besame Mucho](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Richard%20Clayderman%20-%20Besame%20Mucho.pdf) | [YouTube](https://www.youtube.com/watch?v=heU7kt5jx8I)
+[Scarborough Fair](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Scarborough%20Fair.pdf) | [YouTube](https://www.youtube.com/watch?v=2OMFkTM5Mrs)
+[Taeyang - Wedding Dress](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Taeyang%20-%20Wedding%20Dress.pdf) | [YouTube](https://www.youtube.com/watch?v=CmhOlhF2X6s)
+[Train - Drops of Jupiter](https://github.com/JKleinne/PianoSheets/blob/master/Kyle%20Landry/Songs/Train%20-%20Drops%20of%20Jupiter.pdf) | [YouTube](https://www.youtube.com/watch?v=7aXltwtw4w0)
+
+</details>
+
+---
+
+## Video Games
+
+**76 sheets** of video game music, split between the official Final Fantasy Piano Collections and Zohar002's arrangements.
+
+### Final Fantasy Piano Collections
+
+Complete official piano collections for four Final Fantasy titles, located in `Video Games/Final Fantasy/`.
+
+| Collection | Sheets | Notable Tracks |
+|---|--:|---|
+| Final Fantasy VII | 13 | Aerith's Theme, One Winged Angel, Tifa's Theme |
+| Final Fantasy VIII | 13 | Eyes On Me, Fisherman's Horizon, The Oath |
+| Final Fantasy IX | 14 | Melodies of Life, You're Not Alone, Vamo' Alla Flamenco |
+| Final Fantasy X | 15 | To Zanarkand, Suteki Da Ne, Besaid Island |
+
+### Zohar002
+
+<details>
+<summary>21 sheets — Chrono Trigger, Chrono Cross, Xenogears, and more</summary>
+
+Sheet | YouTube
+--- | ---
+[Chrono Trigger - Secret of the Forest (1)](https://github.com/JKleinne/PianoSheets/blob/master/Video%20Games/Zohar002/Chrono%20Trigger%20-%20Secret%20of%20the%20Forest.pdf) | [YouTube](https://www.youtube.com/watch?v=pLx6N98Y6RE)
+[Chrono Trigger - Secret of the Forest (2)](https://github.com/JKleinne/PianoSheets/blob/master/Video%20Games/Zohar002/Chrono%20Trigger%20-%20Secret%20of%20the%20Forest%20(2).pdf) | [YouTube](https://www.youtube.com/watch?v=pLx6N98Y6RE)
+[CEG](https://github.com/JKleinne/PianoSheets/blob/master/Video%20Games/Zohar002/CEG.pdf) | [YouTube](https://www.youtube.com/watch?v=4ckc2BDOYvc)
+[Chrono Cross - Dimension Breach](https://github.com/JKleinne/PianoSheets/blob/master/Video%20Games/Zohar002/Chrono%20Cross%20-%20Dimension%20Breach.pdf) | [YouTube](https://www.youtube.com/watch?v=kQ0ZZUXgswQ)
+[Chrono Trigger - Corridors of Time (1)](https://github.com/JKleinne/PianoSheets/blob/master/Video%20Games/Zohar002/Chrono%20Trigger%20-%20Corridors%20of%20Time.pdf) | [YouTube](https://www.youtube.com/watch?v=kQ0ZZUXgswQ)
+[Chrono Trigger - Corridors of Time (2)](https://github.com/JKleinne/PianoSheets/blob/master/Video%20Games/Zohar002/Chrono%20Trigger%20-%20Corridors%20of%20Time%20(2).pdf) | [YouTube](https://www.youtube.com/watch?v=kQ0ZZUXgswQ)
+[Chrono Trigger - Frog's Theme](https://github.com/JKleinne/PianoSheets/blob/master/Video%20Games/Zohar002/Chrono%20Trigger%20-%20Frog's%20Theme.pdf) | [YouTube](https://www.youtube.com/watch?v=GjHFoptKNZU)
+[Chrono Trigger - Peaceful Days (1)](https://github.com/JKleinne/PianoSheets/blob/master/Video%20Games/Zohar002/Chrono%20Trigger%20-%20Peaceful%20Days.pdf) | [YouTube](https://www.youtube.com/watch?v=9Ua3H3ylnv8)
+[Chrono Trigger - Peaceful Days (2)](https://github.com/JKleinne/PianoSheets/blob/master/Video%20Games/Zohar002/Chrono%20Trigger%20-%20Peaceful%20Days%20(2).pdf) | [YouTube](https://www.youtube.com/watch?v=9Ua3H3ylnv8)
+[Chrono Trigger - Piano Medley](https://github.com/JKleinne/PianoSheets/blob/master/Video%20Games/Zohar002/Chrono%20Trigger%20-%20Piano%20Medley.pdf) |
+[Chrono Trigger - Schala's Theme](https://github.com/JKleinne/PianoSheets/blob/master/Video%20Games/Zohar002/Chrono%20Trigger%20-%20Schala's%20Theme.pdf) | [YouTube](https://www.youtube.com/watch?v=FfIG0Tw0dnw)
+[Chrono Trigger - Singing Mountain](https://github.com/JKleinne/PianoSheets/blob/master/Video%20Games/Zohar002/Chrono%20Trigger%20-%20Singing%20Mountain.pdf) | [YouTube](https://www.youtube.com/watch?v=j7B5wO5_omI)
+[Chrono Trigger - To Far Away Times](https://github.com/JKleinne/PianoSheets/blob/master/Video%20Games/Zohar002/Chrono%20Trigger%20-%20To%20Far%20Away%20Times.pdf) | [YouTube](https://www.youtube.com/watch?v=x_4ndNoraV4)
+[Chrono Trigger - To Good Friends](https://github.com/JKleinne/PianoSheets/blob/master/Video%20Games/Zohar002/Chrono%20Trigger%20-%20To%20Good%20Friends.pdf) | [YouTube](https://www.youtube.com/watch?v=SUk9ybSnMMo)
+[Chrono Trigger - Wind Scene](https://github.com/JKleinne/PianoSheets/blob/master/Video%20Games/Zohar002/Chrono%20Trigger%20-%20Wind%20Scene.pdf) | [YouTube](https://www.youtube.com/watch?v=PY-lLrclanw)
+[Chrono Trigger - Wind Scene Paraphrase](https://github.com/JKleinne/PianoSheets/blob/master/Video%20Games/Zohar002/Chrono%20Trigger%20-%20Wind%20Scene%20Paraphrase.pdf) | [YouTube](https://www.youtube.com/watch?v=_qJzDDTUk7E)
+[Chrono Trigger - World Revolution](https://github.com/JKleinne/PianoSheets/blob/master/Video%20Games/Zohar002/Chrono%20Trigger%20-%20World%20Revolution.pdf) | [YouTube](https://www.youtube.com/watch?v=i25QnaxZSIo)
+[Final Fantasy VI - Aria di Mezzo Carattere](https://github.com/JKleinne/PianoSheets/blob/master/Video%20Games/Zohar002/Final%20Fantasy%20VI%20-%20Aria%20di%20Mezzo%20Carattere.pdf) | [YouTube](https://www.youtube.com/watch?v=lKOB09qIqy4)
+[Saga Frontier - The Opening of a Journey](https://github.com/JKleinne/PianoSheets/blob/master/Video%20Games/Zohar002/Saga%20Frontier%20-%20Opening.pdf) | [YouTube](https://www.youtube.com/watch?v=sEnc3JIzwSk)
+[Saga Frontier - Aserus Ending Theme](https://github.com/JKleinne/PianoSheets/blob/master/Video%20Games/Zohar002/Saga%20Frontier%20-%20Aserus%20Ending%20Theme.pdf) | [YouTube](https://www.youtube.com/watch?v=7io75DIjEVs)
+[Xenogears - Shevat, The Wind is Calling](https://github.com/JKleinne/PianoSheets/blob/master/Video%20Games/Zohar002/Xenogears%20-%20Shevat%2C%20The%20Wind%20is%20Calling.pdf) | [YouTube](https://www.youtube.com/watch?v=CUKBhBqlXzU)
+
+</details>
+
+---
+
+## Jazz
+
+**46 sheets** of jazz piano arrangements, including standards and arranger-specific collections.
+
+Sheet | YouTube
+--- | ---
+[Dream A Little Dream Of Me (*as performed by Scott Bradlee*)](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Dream%20A%20Little%20Dream%20Of%20Me.pdf) | [YouTube](https://www.youtube.com/watch?v=7eC0FuYBKs8)
+[Autumn Leaves](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Autumn%20Leaves.pdf) | [YouTube](https://www.youtube.com/watch?v=OA3Hj7f6ChE)
+[La Vie En Rose](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/La%20Vie%20en%20Rose.pdf) | [YouTube](https://www.youtube.com/watch?v=hgsVsDo8V7Q)
+[Tenderly (*as performed by Art Tatum*)](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Art%20Tatum%20-%20Tenderly.pdf) | [YouTube](https://www.youtube.com/watch?v=meTBMQkcGhQ)
+
+### Hans Piano
+
+<details>
+<summary>25 sheets — jazz standards and pop arrangements (12 with YouTube links)</summary>
+
+Sheet | YouTube
+--- | ---
+[Blue Bossa](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/Blue%20Bossa.pdf) | [YouTube](https://www.youtube.com/watch?v=nU9W38VjZ4I)
+[The Carpenters - Close To You](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/The%20Carpenters%20-%20Close%20To%20You.pdf) | [YouTube](https://www.youtube.com/watch?v=jWvYtv0wrZE)
+[Bee Gees - How Deep Is Your Love](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/How%20Deep%20Is%20Your%20Love.pdf) | [YouTube](https://www.youtube.com/watch?v=65Xza4MayvM)
+[All of Me](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/All%20Of%20Me.pdf) | [YouTube](https://www.youtube.com/watch?v=-w51QfwLaho)
+[Can't Take My Eyes Off You](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/Can't%20Take%20My%20Eyes%20Off%20You.pdf) | [YouTube](https://www.youtube.com/watch?v=1-EZUMCSwUc)
+[Moon River](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/Moon%20River.pdf) | [YouTube](https://www.youtube.com/watch?v=AXPEmv6cUrk)
+[Misty](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/Misty.pdf) | [YouTube](https://www.youtube.com/watch?v=cOKWJSfcWnE)
+[The Way You Look Tonight](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/The%20Way%20You%20Look%20Tonight.pdf) | [YouTube](https://www.youtube.com/watch?v=gtnXveHiKyo)
+[Unforgettable](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/Unforgettable.pdf) | [YouTube](https://www.youtube.com/watch?v=Dkw8K2s8s3k)
+[Christmas Medley](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/Christmas%20Medleys.pdf) | [YouTube](https://www.youtube.com/watch?v=Fd6DClQoL2k)
+[Fly Me To The Moon](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/Fly%20Me%20To%20The%20Moon.pdf) | [YouTube](https://www.youtube.com/watch?v=Z6U-8xF7e8A)
+[Just The Two Of Us](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/Hans%20piano/Just%2BTwo%2BOf%2BUs.pdf) | [YouTube](https://www.youtube.com/watch?v=0Ocl42QliEE)
+
+</details>
+
+### RPA (Rupert Austin)
+
+<details>
+<summary>17 sheets — jazz standard transcriptions</summary>
+
+Sheet | YouTube
+--- | ---
+[Misty](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Misty.pdf) | [YouTube](https://www.youtube.com/watch?v=vhRwSAbA-CQ)
+[Autumn Leaves](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Autumn%20Leaves.pdf) | [YouTube](https://www.youtube.com/watch?v=HQ_IUUtDJW8)
+[Somewhere Over The Rainbow](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Over%20the%20Rainbow.pdf) | [YouTube](https://www.youtube.com/watch?v=SEwqRF-_hsk)
+[A Time For Love](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_A%20Time%20For%20Love.pdf) | [YouTube](https://www.youtube.com/watch?v=SJUSt69mnN8)
+[Bewitched, Bothered and Bewildered](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Bewitched.pdf) | [YouTube](https://www.youtube.com/watch?v=mZOI4AGn0WM)
+[Close Enough For Love](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Close%20Enough%20For%20Love.pdf) | [YouTube](https://www.youtube.com/watch?v=aDSgd7E9KS4)
+[East of the Sun (and West of the Moon)](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_East%20of%20the%20Sun%20and%20West%20of%20the%20moon.pdf) | [YouTube](https://www.youtube.com/watch?v=TzA_vXbJG8g)
+[How Deep Is The Ocean](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_How%20Deep%20Is%20The%20Ocean.pdf) | [YouTube](https://www.youtube.com/watch?v=O51RLWnXjvM)
+[I Remember You](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_I%20Remember%20You.pdf) | [YouTube](https://www.youtube.com/watch?v=IXMqhKqLhyU)
+[Love Letters (Straight From Your Heart)](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Love%20Letters.pdf) | [YouTube](https://www.youtube.com/watch?v=Sq1e0lJLVvQ)
+[On Green Dolphin Street](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_On%20Green%20Dolphin%20Street.pdf) | [YouTube](https://www.youtube.com/watch?v=xm3yuGM5kFk)
+[On A Clear Day (You Can See Forever)](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_On%20a%20Clear%20Day.pdf) | [YouTube](https://www.youtube.com/watch?v=m18MT0wTk-4)
+[Polka Dots and Moonbeams](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Polka%20Dots%20and%20Moonbeams.pdf) | [YouTube](https://www.youtube.com/watch?v=PjyYO5QWDgI)
+[Softly As In A Morning Sunrise](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Softly%20as%20in%20a%20Morning%20Sunrise.pdf) | [YouTube](https://www.youtube.com/watch?v=MX7onUERjwY)
+[Someone To Watch Over Me](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Someone%20To%20Watch%20Over%20Me.pdf) | [YouTube](https://www.youtube.com/watch?v=JGIuAO1auI8)
+[Stella By Starlight](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Stella%20By%20Starlight.pdf) | [YouTube](https://www.youtube.com/watch?v=S_ndumRgcNM)
+[Summertime](https://github.com/JKleinne/PianoSheets/blob/master/Jazz/RPA/RPA_Summertime.pdf) | [YouTube](https://www.youtube.com/watch?v=obC5waiXlIQ)
+
+</details>
+
+---
+
+## Vika Yermalova (Vkgoeswild)
+
+**20 sheets** of rock and pop piano adaptations by [Vkgoeswild](https://www.youtube.com/user/Vkgoeswild). Features arrangements of classic rock staples from Queen, Guns N' Roses, Pink Floyd, Led Zeppelin, Metallica, and others.
+
+Sheet | YouTube
+--- | ---
+[Scorpions - Wind Of Change](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Wind%20of%20Change.pdf) | [YouTube](https://www.youtube.com/watch?v=fKBvaeSboNk)
+[Queen - Bohemian Rhapsody](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Bohemian%20Raphsody.pdf) | [YouTube](https://www.youtube.com/watch?v=rptV6K7nqu0)
+[Queen - Who Wants To Live Forever](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Who%20wants%20to%20live%20forever.pdf) | [YouTube](https://www.youtube.com/watch?v=InbDWywMbfM)
+[Queen - Somebody To Love](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Somebody%20to%20Love.pdf) | [YouTube](https://www.youtube.com/watch?v=XYrlrMtAB3M)
+[Coldplay - Clocks](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Clocks.pdf) | [YouTube](https://www.youtube.com/watch?v=fOop0dE8hQI)
+[Pink Floyd - Comfortably Numb](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Comfortably%20Numb.pdf) | [YouTube](https://www.youtube.com/watch?v=sq1TTCi9RVA)
+[Pink Floyd - Echoes](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Echoes.pdf) | [YouTube](https://www.youtube.com/watch?v=FI0fyOaD94Y)
+[Eagles - Hotel California](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Hotel%20California.pdf) | [YouTube](https://www.youtube.com/watch?v=Z3bxLL2eMYc)
+[Phil Collins - In The Air Tonight](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/In%20The%20Air%20Tonight.pdf) | [YouTube](https://www.youtube.com/watch?v=t_3S0mcNe08)
+[Guns N' Roses - Knocking on Heaven's Door](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Knocking%20on%20Heaven's%20Door.pdf) | [YouTube](https://www.youtube.com/watch?v=GiZDgdE8SUk)
+[Guns N' Roses - November Rain](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/November%20Rain.pdf) | [YouTube](https://www.youtube.com/watch?v=FhbeNEtkgDs)
+[Guns N' Roses - Sweet Child o' Mine](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Sweet%20Child.pdf) | [YouTube](https://www.youtube.com/watch?v=ff8UwvPK0G4)
+[Guns N' Roses - This I Love](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/This%20I%20Love.pdf) | [YouTube](https://www.youtube.com/watch?v=i6y0sK2vzd0)
+[Metallica - Nothing Else Matters](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Nothing%20Matters.pdf) | [YouTube](https://www.youtube.com/watch?v=Six5zn4oXGE)
+[Metallica - One](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Metallica%20-%20One.pdf) | [YouTube](https://www.youtube.com/watch?v=4_3whe5_G2g)
+[Extreme - More Than Words](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/More%20Than%20Words.pdf) | [YouTube](https://www.youtube.com/watch?v=R5KBk76b9HE)
+[Pantera - Cemetery Gates](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Pantera%20Cemetary%20Gates.pdf) | [YouTube](https://www.youtube.com/watch?v=Pl5KnzgDyDY)
+[The Pixies - Where Is My Mind](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Pixies%20where%20is%20my%20mind.pdf) | [YouTube](https://www.youtube.com/watch?v=KFiScXBMR7E)
+[Led Zeppelin - Stairway To Heaven](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/Stairway%20to%20heaven.pdf) | [YouTube](https://www.youtube.com/watch?v=dwWmVLKdHPE)
+[R.E.M. - Everybody Hurts](https://github.com/JKleinne/PianoSheets/blob/master/Vika%20Yermalova%20(Vkgoeswild)/R.E.M.%20-%20Everybody%20Hurts.pdf) |
+
+---
+
+## Other Collections
+
+### Personal Favorites
+
+**18 sheets** — a curated cross-genre selection of standout pieces from across the repository.
+
+- Beethoven Virus Jazz
+- Chrono Trigger - Secret of the Forest
+- Cortazar - Beethoven Silencio
+- Hotel California
+- Howl's Moving Castle Theme
+- La La Land - Mia & Sebastian's Theme (Kyle Landry's Arr.)
+- La Vie en Rose
+- Mozart - Lacrimosa (arr. by Liszt)
+- Mozart - Lacrimosa (arr. by Thalberg)
+- Nocturne in C# minor
+- Rachmaninoff - Prelude in C# Minor
+- Richard Clayderman - Besame Mucho
+- Sonate No. 8 Pathetique 1st Movement
+- Steins;Gate - Gate of Steiner (Takeshi Abo ver.)
+- Steins;Gate 0 - Gate of Steiner
+- Wind of Change
+- Winter Sonata - From The Beginning Until Now
+- Yiruma - Scenery from My Window
+
+### Misc
+
+**20 sheets** — uncategorized pieces including Chrono Trigger/Cross arrangements, Final Fantasy (XIV, XV), Steins;Gate, Sailor Moon, and other standalone transcriptions.
+
+### richard-clayderman
+
+**6 sheets** of romantic piano arrangements:
+
+- A Comme Amour
+- Ballade pour Adeline
+- Eleana
+- Feelings
+- La Vie en Rose
+- Strangers in the Night
+
+### Collections
+
+**2 bound volumes** containing complete multi-piece collections:
+
+- Final Fantasy VII - Piano Collection (complete bound score)
+- The Piano Solos of Richard Clayderman
+
+### Beethoven Virus
+
+**2 sheets** — the viral piano arrangement in two versions:
+
+- Beethoven Virus (Allegro)
+- Beethoven Virus Jazz
+
+---
+
+## Full Inventory
+
+For a complete file-by-file listing of all 1,583 sheets across 102 directories, see **[tree.txt](https://github.com/JKleinne/PianoSheets/blob/master/tree.txt)**.
+
+All credits belong to their respective artists and arrangers.


### PR DESCRIPTION
## What
Complete rewrite of readme.md — adds missing collections, fixes broken links, and restructures with collapsible sections.

## Why
The previous readme was severely outdated — entire major collections (Classical, Mercuziopianist, Yiruma, Video Games, Personal Favorites, Misc, etc.) were completely absent. It also contained bugs: a broken GitHub link, a mislabeled anchor, and a reference to a deleted directory.

## Changes
- Add summary sections for large collections: Classical (511), Mercuziopianist (548), Yiruma (172)
- Preserve existing curated YouTube-linked tables for Kyle Landry, Jazz, Vika Yermalova, Zohar002 — wrapped in collapsible `<details>` sections
- Add new sections for Video Games/FF Piano Collections, Personal Favorites, Misc, richard-clayderman, Collections, Beethoven Virus
- Add "At a Glance" summary table and linked Table of Contents
- Fix broken Pinocchio link (`mstty` → `JKleinne`)
- Fix duplicate `<a name="movies">` anchor on Songs section
- Remove Jonny May section (directory doesn't exist)
- Fix Zohar002 paths from `/Zohar002/` to `/Video Games/Zohar002/`
- Add missing R.E.M. - Everybody Hurts entry to Vika Yermalova